### PR TITLE
Fix NFS mount

### DIFF
--- a/nx/storage_monitor.py
+++ b/nx/storage_monitor.py
@@ -71,7 +71,8 @@ class StorageMonitor(BaseAgent):
 
 
     def mount(self, storage):
-        if storage["protocol"] == "samba":
+        protocol = storage["protocol"]
+        if protocol == "samba":
             smbopts = {}
             if storage.get("login"):
                 smbopts["user"] = storage["login"]
@@ -93,7 +94,7 @@ class StorageMonitor(BaseAgent):
             cmd = "mount.cifs {} {}{}".format(storage["path"], storage.local_path, opts)
 
 
-        elif protocol == NFS:
+        elif protocol == 'nfs':
             executable = "mount.nfs"
             cmd = "mount.nfs {} {}".format(storage["path"], storage.local_path)
 


### PR DESCRIPTION
I don't know where does NFS constant come from, So I assume it would be `nfs` as literal string.

Here were the error message and storage settings I met:

```
nebula=> SELECT * FROM storages;
 id |                                    settings
----+---------------------------------------------------------------------------------
  1 | {"path": "127.0.0.1:/mnt/production", "title": "production", "protocol": "nfs"}
  2 | {"path": "127.0.0.1:/mnt/playout", "title": "playout", "protocol": "nfs"}
(2 rows)
```
```
2020-10-06 09:43:03 ERROR       nebula          Exception!

    Traceback (most recent call last):
      File "/opt/nebula/nx/agents.py", line 40, in run
        self.main()
      File "/opt/nebula/nx/storage_monitor.py", line 57, in main
        self.mount(storage)
      File "/opt/nebula/nx/storage_monitor.py", line 96, in mount
        elif storage["protocol"] == NFS:
    NameError: name 'NFS' is not defined
```