### PR TITLE
Multi-select support in browser

### DIFF
--- a/backend/server/websocket.py
+++ b/backend/server/websocket.py
@@ -129,7 +129,7 @@ class Messaging(BackgroundTask):
                         continue
                 else:
                     data = json_loads(raw_message["data"])
-                    message = {
+                    message: dict[str, Any] = {
                         "timestamp": data[0],
                         "site": data[1],
                         "host": data[2],

--- a/backend/server/websocket.py
+++ b/backend/server/websocket.py
@@ -120,6 +120,7 @@ class Messaging(BackgroundTask):
                     ignore_subscribe_messages=True,
                     timeout=2,
                 )
+                message: dict[str, Any]
                 if raw_message is None:
                     await asyncio.sleep(0.01)
                     if time.time() - last_msg > 3:
@@ -129,7 +130,7 @@ class Messaging(BackgroundTask):
                         continue
                 else:
                     data = json_loads(raw_message["data"])
-                    message: dict[str, Any] = {
+                    message = {
                         "timestamp": data[0],
                         "site": data[1],
                         "host": data[2],
@@ -137,8 +138,10 @@ class Messaging(BackgroundTask):
                         "data": data[4],
                     }
 
-                if message["topic"] == "log" and message["data"].get("level", 0) > 3:
-                    self.handle_error_log()
+                if message["topic"] == "log":
+                    assert isinstance(message["data"], dict)
+                    if message["data"].get("level", 0) > 3:
+                        self.handle_error_log()
 
                 clients = list(self.clients.values())
                 for client in clients:

--- a/frontend/src/components/ErrorBanner.jsx
+++ b/frontend/src/components/ErrorBanner.jsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components'
+
+const ErrorBanner = styled.div`
+  padding: 20px;
+  background-color: var(--color-surface-04);
+  color: var(--color-red);
+  margin: 10px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 700;
+`
+
+export default ErrorBanner

--- a/frontend/src/components/index.jsx
+++ b/frontend/src/components/index.jsx
@@ -1,6 +1,7 @@
 export { default as Table } from './table'
 export { default as Dialog } from './Dialog'
 export { default as Dropdown } from './Dropdown'
+export { default as ErrorBanner } from './ErrorBanner'
 export { default as Loader } from './Loader'
 export { default as Progress } from './Progress'
 export { default as Select } from './Select'

--- a/frontend/src/components/table/cells.jsx
+++ b/frontend/src/components/table/cells.jsx
@@ -48,8 +48,8 @@ const DataRow = ({
   rowHighlightColor,
   selected = false,
 }) => {
-  const handleClick = () => {
-    if (onRowClick) onRowClick(rowData)
+  const handleClick = (event) => {
+    if (onRowClick) onRowClick(rowData, event)
   }
   const rowStyle = {}
 

--- a/frontend/src/components/table/container.jsx
+++ b/frontend/src/components/table/container.jsx
@@ -9,6 +9,10 @@ const TableWrapper = styled.div`
     width: 100%;
     border-collapse: collapse;
 
+    :focus {
+      outline: none;
+    }
+
     tr {
       border-left: 2px solid var(--color-surface-02);
     }
@@ -23,6 +27,7 @@ const TableWrapper = styled.div`
       padding: 4px 8px;
       max-width: 300px;
       color: var(--color-text);
+      user-select: none;
     }
 
     th div {
@@ -101,12 +106,16 @@ const TableWrapper = styled.div`
         cursor: pointer;
         background-color: transparent;
         &:hover {
-          background-color: var(--color-surface-04);
+          background-color: var(--color-surface-03);
         }
 
         &.selected {
           background-color: var(--color-surface-05);
           color: var(--color-text-hl);
+
+          &:hover {
+            background-color: var(--color-surface-06);
+          }
         }
 
         &:before {

--- a/frontend/src/components/table/index.jsx
+++ b/frontend/src/components/table/index.jsx
@@ -72,7 +72,12 @@ const Table = ({
   }
 
   return (
-    <TableWrapper className={className} style={style} onScroll={handleScroll} onKeyDown={handleKeyDown}>
+    <TableWrapper
+      className={className}
+      style={style}
+      onScroll={handleScroll}
+      onKeyDown={handleKeyDown}
+    >
       {loading && (
         <div className="contained center">
           <Loader />

--- a/frontend/src/components/table/index.jsx
+++ b/frontend/src/components/table/index.jsx
@@ -11,6 +11,7 @@ const Table = ({
   style,
   keyField,
   onRowClick,
+  onKeyDown,
   selection,
   rowHighlightColor,
   sortBy,
@@ -35,6 +36,12 @@ const Table = ({
       </thead>
     )
   }, [columns, sortBy, sortDirection, onSort])
+
+  const handleKeyDown = (event) => {
+    if (onKeyDown) {
+      onKeyDown(event)
+    }
+  }
 
   const body = useMemo(() => {
     return (
@@ -65,13 +72,13 @@ const Table = ({
   }
 
   return (
-    <TableWrapper className={className} style={style} onScroll={handleScroll}>
+    <TableWrapper className={className} style={style} onScroll={handleScroll} onKeyDown={handleKeyDown}>
       {loading && (
         <div className="contained center">
           <Loader />
         </div>
       )}
-      <table>
+      <table onKeyDown={handleKeyDown} tabIndex={0}>
         {head}
         {body}
       </table>

--- a/frontend/src/containers/Browser/Browser.jsx
+++ b/frontend/src/containers/Browser/Browser.jsx
@@ -11,10 +11,13 @@ import {
 
 import { useLocalStorage } from '/src/hooks'
 import BrowserNav from './BrowserNav'
-import { getColumnWidth, getFormatter, formatRowHighlightColor } from './Formatting.jsx'
+import {
+  getColumnWidth,
+  getFormatter,
+  formatRowHighlightColor,
+} from './Formatting.jsx'
 
 const ROWS_PER_PAGE = 200
-
 
 const Pagination = ({ page, setPage, hasMore }) => {
   if (page > 1 || hasMore)
@@ -98,40 +101,36 @@ const BrowserTable = () => {
     loadData()
   }, [currentView, searchQuery, browserRefresh, sortBy, sortDirection, page])
 
-
   const onRowClick = (rowData, event) => {
-    let newSelectedAssets = [];
+    let newSelectedAssets = []
     if (event.ctrlKey) {
       if (selectedAssets.includes(rowData.id)) {
-        newSelectedAssets = selectedAssets.filter(obj => obj !== rowData.id);
+        newSelectedAssets = selectedAssets.filter((obj) => obj !== rowData.id)
       } else {
-        newSelectedAssets = [...selectedAssets, rowData.id];
+        newSelectedAssets = [...selectedAssets, rowData.id]
       }
     } else if (event.shiftKey) {
-
-      const clickedIndex = data.findIndex((row) => row.id === rowData.id);
-      const focusedIndex = data.findIndex((row) => row.id === focusedAsset) ||
+      const clickedIndex = data.findIndex((row) => row.id === rowData.id)
+      const focusedIndex =
+        data.findIndex((row) => row.id === focusedAsset) ||
         data.findIndex((row) => selectedAssets.includes(row.id)) ||
         clickedIndex ||
-        0;
+        0
 
-      
-      const min = Math.min(clickedIndex, focusedIndex);
-      const max = Math.max(clickedIndex, focusedIndex);
+      const min = Math.min(clickedIndex, focusedIndex)
+      const max = Math.max(clickedIndex, focusedIndex)
 
       // Get the ids of the rows in the range
-      const rangeIds = data.slice(min, max + 1).map(row => row.id);
+      const rangeIds = data.slice(min, max + 1).map((row) => row.id)
 
-      newSelectedAssets = [...new Set([...selectedAssets, ...rangeIds])];
-
+      newSelectedAssets = [...new Set([...selectedAssets, ...rangeIds])]
     } else {
-      newSelectedAssets = [rowData.id];
+      newSelectedAssets = [rowData.id]
     }
 
     dispatch(setSelectedAssets(newSelectedAssets))
     dispatch(setFocusedAsset(rowData.id))
   }
-
 
   const focusNext = (offset) => {
     if (!focusedAsset) return
@@ -143,7 +142,6 @@ const BrowserTable = () => {
     }
   }
 
-
   const onKeyDown = (e) => {
     if (e.key === 'ArrowDown') {
       focusNext(1)
@@ -154,7 +152,6 @@ const BrowserTable = () => {
       e.preventDefault()
     }
   }
-
 
   return (
     <>

--- a/frontend/src/containers/Browser/Formatting.jsx
+++ b/frontend/src/containers/Browser/Formatting.jsx
@@ -1,0 +1,128 @@
+import nebula from '/src/nebula'
+import styled from 'styled-components'
+import { Timecode } from '@wfoxall/timeframe'
+import { Timestamp } from '/src/components'
+
+const QCState = styled.div`
+  display: inline-block;
+  &::before {
+    content: '⚑';
+  }
+
+  &.qc-state-3 {
+    color: var(--color-red);
+  }
+
+  &.qc-state-4 {
+    color: var(--color-green);
+  }
+`
+
+const formatRowHighlightColor = (rowData) => {
+  switch (rowData['status']) {
+    case 0:
+      return 'var(--color-red)'
+    case 2:
+      return 'var(--color-yellow)' // creating
+    case 3:
+      return 'var(--color-violet)' // trashed
+    case 4:
+      return 'var(--color-blue)' // archived
+    case 5:
+      return 'var(--color-yellow)' // reset
+    case 6:
+      return 'var(--color-red)' // corrupted
+    case 11:
+      return 'var(--color-yellow)' // retrieving
+    default:
+      return 'transparent'
+  }
+}
+
+// Column width
+
+const getColumnWidth = (key) => {
+  if (!['title', 'subtitle', 'description'].includes(key)) return '1px'
+}
+
+// Field formatters
+
+const getFormatter = (key) => {
+  if (['title', 'subtitle', 'description'].includes(key))
+    return (rowData, key) => <td>{rowData[key]}</td>
+
+  switch (key) {
+    case 'qc/state':
+      return (rowData, key) => (
+        <td>
+          <QCState className={`qc-state-${rowData[key]}`} />
+        </td>
+      )
+
+    case 'id_folder':
+      return (rowData, key) => {
+        const folder = nebula.settings.folders.find(
+          (f) => f.id === rowData[key]
+        )
+        return <td style={{ color: folder?.color }}>{folder?.name}</td>
+      }
+
+    case 'duration':
+      return (rowData, key) => {
+        const fps = rowData['video/fps_f'] || 25
+        const duration = rowData[key] || 0
+        const timecode = new Timecode(duration * fps, fps)
+        return <td>{timecode.toString().substring(0, 11)}</td>
+      }
+
+    case 'created_by':
+      return (rowData, key) => {
+        return <td>{nebula.getUserName(rowData[key])}</td>
+      }
+
+    case 'updated_by':
+      return (rowData, key) => {
+        return <td>{nebula.getUserName(rowData[key])}</td>
+      }
+
+    default:
+      const metaType = nebula.metaType(key)
+      switch (metaType.type) {
+        case 'boolean':
+          return (rowData, key) => <td>{rowData[key] ? '✓' : ''}</td>
+
+        case 'datetime':
+          return (rowData, key) => (
+            <td>
+              <Timestamp timestamp={rowData[key]} mode={metaType.mode} />{' '}
+            </td>
+          )
+
+        case 'select':
+          return (rowData, key) => {
+            if (!metaType.cs) return <td>{rowData[key]}</td>
+
+            const option = nebula
+              .csOptions(metaType.cs)
+              .find((opt) => opt.value === rowData[key])
+
+            return <td>{option?.title}</td>
+          }
+
+        case 'list':
+          return (rowData, key) => {
+            if (!metaType.cs) return <td>{rowData[key].join(', ')}</td>
+            const options = nebula
+              .csOptions(metaType.cs)
+              .filter((opt) => rowData[key].includes(opt.value))
+            return <td>{options.map((opt) => opt.title).join(', ')}</td>
+          }
+
+        default:
+          return (rowData, key) => <td>{rowData[key]}</td>
+      } // switch metaType
+  } // end switch key
+} // end getFormatter
+
+
+export { getColumnWidth, getFormatter, formatRowHighlightColor }

--- a/frontend/src/containers/Browser/Formatting.jsx
+++ b/frontend/src/containers/Browser/Formatting.jsx
@@ -124,5 +124,4 @@ const getFormatter = (key) => {
   } // end switch key
 } // end getFormatter
 
-
 export { getColumnWidth, getFormatter, formatRowHighlightColor }

--- a/frontend/src/containers/SendTo.jsx
+++ b/frontend/src/containers/SendTo.jsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux'
 import { toast } from 'react-toastify'
 import { Dialog, Button, ErrorBanner } from '/src/components'
 
-
 const SendToDialog = ({ onHide }) => {
   const [sendToOptions, setSendToOptions] = useState(null)
   const selectedAssets = useSelector((state) => state.context.selectedAssets)
@@ -32,8 +31,7 @@ const SendToDialog = ({ onHide }) => {
   }
 
   const body = useMemo(() => {
-    if (!sendToOptions) 
-      return null
+    if (!sendToOptions) return null
     if (sendToOptions.length === 0) {
       return (
         <ErrorBanner>
@@ -61,8 +59,10 @@ const SendToDialog = ({ onHide }) => {
     return <Button label="Cancel" onClick={onHide} icon="close" />
   }, [sendToOptions])
 
-
-  const what = (selectedAssets.length === 1) ? 'the asset' : `${selectedAssets.length} assets`
+  const what =
+    selectedAssets.length === 1
+      ? 'the asset'
+      : `${selectedAssets.length} assets`
 
   return (
     <Dialog

--- a/frontend/src/containers/SendTo.jsx
+++ b/frontend/src/containers/SendTo.jsx
@@ -6,7 +6,7 @@ import { Dialog, Button, ErrorBanner } from '/src/components'
 
 
 const SendToDialog = ({ onHide }) => {
-  const [sendToOptions, setSendToOptions] = useState([])
+  const [sendToOptions, setSendToOptions] = useState(null)
   const selectedAssets = useSelector((state) => state.context.selectedAssets)
 
   const loadOptions = () => {
@@ -32,7 +32,9 @@ const SendToDialog = ({ onHide }) => {
   }
 
   const body = useMemo(() => {
-    if (sendToOptions.length) {
+    if (!sendToOptions) 
+      return null
+    if (sendToOptions.length === 0) {
       return (
         <ErrorBanner>
           No actions available for the current selection
@@ -55,7 +57,7 @@ const SendToDialog = ({ onHide }) => {
   }, [sendToOptions])
 
   const footer = useMemo(() => {
-    if (sendToOptions.length === 0) return null
+    if (!sendToOptions?.length) return null
     return <Button label="Cancel" onClick={onHide} icon="close" />
   }, [sendToOptions])
 

--- a/frontend/src/containers/SendTo.jsx
+++ b/frontend/src/containers/SendTo.jsx
@@ -1,24 +1,26 @@
 import nebula from '/src/nebula'
 import { useState, useEffect, useMemo } from 'react'
+import { useSelector } from 'react-redux'
 import { toast } from 'react-toastify'
 import { Dialog, Button } from '/src/components'
 
-const SendToDialog = ({ assets, onHide }) => {
+const SendToDialog = ({ onHide }) => {
   const [sendToOptions, setSendToOptions] = useState([])
+  const selectedAssets = useSelector((state) => state.context.selectedAssets)
 
   const loadOptions = () => {
-    nebula.request('actions', { ids: assets }).then((response) => {
+    nebula.request('actions', { ids: selectedAssets }).then((response) => {
       setSendToOptions(response.data.actions)
     })
   }
 
   useEffect(() => {
     loadOptions()
-  }, [assets])
+  }, [selectedAssets])
 
   const onSend = (action) => {
     nebula
-      .request('send', { ids: assets, id_action: action })
+      .request('send', { ids: selectedAssets, id_action: action })
       .then(() => {
         toast.success('Job request accepted')
         onHide()
@@ -29,7 +31,13 @@ const SendToDialog = ({ assets, onHide }) => {
   }
 
   const body = useMemo(() => {
-    if (sendToOptions.length === 0) return null
+    if (sendToOptions.length === 0) {
+      return (
+        <p>
+          No actions available for the current selection
+        </p>
+      )
+    }
     return (
       <>
         {sendToOptions.map((option) => {
@@ -50,11 +58,14 @@ const SendToDialog = ({ assets, onHide }) => {
     return <Button label="Cancel" onClick={onHide} icon="close" />
   }, [sendToOptions])
 
+
+  const what = (selectedAssets.length === 1) ? 'the asset' : `${selectedAssets.length} assets`
+
   return (
     <Dialog
       onHide={onHide}
       style={{ width: 600 }}
-      header="Send to..."
+      header={`Send ${what} to...`}
       footer={footer}
     >
       {body}

--- a/frontend/src/containers/SendTo.jsx
+++ b/frontend/src/containers/SendTo.jsx
@@ -2,7 +2,8 @@ import nebula from '/src/nebula'
 import { useState, useEffect, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { toast } from 'react-toastify'
-import { Dialog, Button } from '/src/components'
+import { Dialog, Button, ErrorBanner } from '/src/components'
+
 
 const SendToDialog = ({ onHide }) => {
   const [sendToOptions, setSendToOptions] = useState([])
@@ -31,11 +32,11 @@ const SendToDialog = ({ onHide }) => {
   }
 
   const body = useMemo(() => {
-    if (sendToOptions.length === 0) {
+    if (sendToOptions.length) {
       return (
-        <p>
+        <ErrorBanner>
           No actions available for the current selection
-        </p>
+        </ErrorBanner>
       )
     }
     return (

--- a/frontend/src/index.sass
+++ b/frontend/src/index.sass
@@ -8,6 +8,7 @@
   --color-surface-03: #24202e
   --color-surface-04: #2e2a38
   --color-surface-05: #302c3a
+  --color-surface-06: #3a3544
   --color-text: #d7d4d5
   --color-text-hl: #fbfbfb
   --color-text-dim: #ababab

--- a/frontend/src/pages/AssetEditor/EditorNav.jsx
+++ b/frontend/src/pages/AssetEditor/EditorNav.jsx
@@ -1,8 +1,9 @@
 import nebula from '/src/nebula'
 
-import { useDispatch } from 'react-redux'
+import { toast } from 'react-toastify'
+import { useSelector, useDispatch } from 'react-redux'
 import { useState, useMemo } from 'react'
-import { setCurrentViewId, setSearchQuery } from '/src/actions'
+import { setCurrentViewId, setSearchQuery, reloadBrowser } from '/src/actions'
 import {
   Navbar,
   Button,
@@ -36,6 +37,7 @@ const AssetEditorNav = ({
   const [detailsVisible, setDetailsVisible] = useState(false)
   const [sendToVisible, setSendToVisible] = useState(false)
   const [contextActionResult, setContextActionResult] = useState(null)
+  const selectedAssets = useSelector((state) => state.context.selectedAssets)
 
   const dispatch = useDispatch()
 
@@ -56,6 +58,23 @@ const AssetEditorNav = ({
   }, [])
 
   // Actions
+
+
+  const setSelectionStatus = (status) => {
+    const operations = selectedAssets.map((id) => ({
+      id,
+      data: { status },
+    }))
+    nebula
+      .request('ops', {operations})
+      .then(() => {
+        toast.success('Request accepted')
+        dispatch(reloadBrowser())
+      })
+      .catch((error) => {
+        toast.error(error.response.detail)
+      })
+  }
 
   const scopedEndpoints = useMemo(() => {
     const result = []
@@ -102,7 +121,8 @@ const AssetEditorNav = ({
         label: 'Reset',
         disabled: assetData.status !== 1,
         onClick: () => {
-          setMeta('status', 5, true)
+          //setMeta('status', 5, true)
+          setSelectionStatus(5)
         },
       },
       ...scopedEndpoints,

--- a/frontend/src/pages/AssetEditor/EditorNav.jsx
+++ b/frontend/src/pages/AssetEditor/EditorNav.jsx
@@ -59,14 +59,13 @@ const AssetEditorNav = ({
 
   // Actions
 
-
   const setSelectionStatus = (status) => {
     const operations = selectedAssets.map((id) => ({
       id,
       data: { status },
     }))
     nebula
-      .request('ops', {operations})
+      .request('ops', { operations })
       .then(() => {
         toast.success('Request accepted')
         dispatch(reloadBrowser())


### PR DESCRIPTION
Selecting more assets using ctrl/shift in the browser is now supported. Supported actions for multi-selections are:

- send to
- reset

## Additional features:

- Browser keyboard navigation

## Not supported (yet):

- Trashing / untrashing / archiving / unarchiving (this is tricky as it requires broader context)
- Metadata editing of multiple assets
- Much more intuitive will be a context menu - also it would allow mentioned contextual actions (different PR)