### PR TITLE
Renamed serie/series folders

### DIFF
--- a/backend/setup/defaults/folders.py
+++ b/backend/setup/defaults/folders.py
@@ -60,7 +60,7 @@ FOLDERS: list[FolderSettings] = [
     ),
     FolderSettings(
         id=2,
-        name="Serie",
+        name="Episode",
         color="#0397bb",
         fields=[
             *primary_description,
@@ -183,7 +183,7 @@ FOLDERS: list[FolderSettings] = [
     ),
     FolderSettings(
         id=13,
-        name="Series",
+        name="Serie",
         color="#a0aac5",
         fields=[
             *primary_description,


### PR DESCRIPTION
Backwards compatible change to make folder name more readable:

- 2: `Serie` -> `Episode`
- 13: `Series` -> `Serie`