### PR TITLE
Friendlier asset editor navbar

### DIFF
--- a/frontend/src/components/Button.jsx
+++ b/frontend/src/components/Button.jsx
@@ -10,11 +10,22 @@ const BaseButton = styled.button`
   background: ${(props) => props.theme.inputBackground};
   color: ${(props) => props.theme.colors.text};
   font-size: ${(props) => props.theme.fontSize};
-  padding-left: ${(props) => props.theme.inputPadding};
-  padding-right: ${(props) => props.theme.inputPadding};
+  padding-left: 12px;
+  padding-right: 12px;
   min-height: ${(props) => props.theme.inputHeight};
   max-height: ${(props) => props.theme.inputHeight};
   min-width: ${(props) => props.theme.inputHeight} !important;
+
+  &.icon-only {
+    padding: 0;
+    min-width: ${(props) => props.theme.inputHeight};
+    max-width: ${(props) => props.theme.inputHeight};
+    min-height: ${(props) => props.theme.inputHeight};
+    max-height: ${(props) => props.theme.inputHeight};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 
   user-select: none;
   user-drag: none;
@@ -22,7 +33,7 @@ const BaseButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: 8px;
   cursor: pointer;
   white-space: nowrap;
 
@@ -76,7 +87,7 @@ const Button = forwardRef(
     return (
       <BaseButton
         {...props}
-        className={clsx(className, { active })}
+        className={clsx(className, { active }, !label && 'icon-only')}
         title={tooltip}
         ref={ref}
       >

--- a/frontend/src/components/RadioButton.jsx
+++ b/frontend/src/components/RadioButton.jsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components'
+
+import { forwardRef } from 'react'
+import clsx from 'clsx'
+
+import Button from './Button'
+
+const RadioContainer = styled.div`
+  display: flex;
+  gap: 1px;
+
+  button {
+    border-radius: 0;
+    border-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+
+    &:first-child {
+      border-top-left-radius: 4px;
+      border-bottom-left-radius: 4px;
+    }
+
+    &:last-child {
+      border-top-right-radius: 4px;
+      border-bottom-right-radius: 4px;
+    }
+
+`
+
+const RadioButton = ({ options, value, onChange }) => {
+  return (
+    <RadioContainer>
+      {options.map((option) => (
+        <Button
+          key={option.value}
+          onClick={() => onChange(option.value)}
+          className={clsx({ active: option.value === value })}
+          icon={option.icon}
+          label={option.label}
+          tooltip={option.tooltip}
+          style={option.buttonStyle}
+        />
+      ))}
+    </RadioContainer>
+  )
+}
+
+export default RadioButton

--- a/frontend/src/components/index.jsx
+++ b/frontend/src/components/index.jsx
@@ -17,6 +17,7 @@ export { default as TextArea } from './TextArea'
 export { default as Button } from './Button'
 export { default as DatePicker } from './DatePicker'
 export { default as Canvas } from './Canvas'
+export { default as RadioButton } from './RadioButton'
 
 export { DateTime, Timestamp } from './Fields'
 export { Form, FormRow } from './Form'

--- a/frontend/src/containers/Upload.jsx
+++ b/frontend/src/containers/Upload.jsx
@@ -231,7 +231,7 @@ const UploadButton = ({ assetData, disabled }) => {
       )}
       <Button
         icon="upload"
-        tooltip="Upload media file"
+        label="Upload media"
         onClick={() => setDialogVisible(true)}
         disabled={disabled}
       />

--- a/frontend/src/pages/AssetEditor/AssetEditor.jsx
+++ b/frontend/src/pages/AssetEditor/AssetEditor.jsx
@@ -70,10 +70,7 @@ const AssetEditor = () => {
   const [originalData, setOriginalData] = useState({})
   const [loading, setLoading] = useState(false)
   const [ConfirmDialog, confirm] = useConfirm()
-  const [previewVisible, setPreviewVisible] = useLocalStorage(
-    'previewVisible',
-    false
-  )
+  const [editorMode, setEditorMode] = useLocalStorage('editorMode', 'metadata')
 
   // Load asset data
 
@@ -295,41 +292,52 @@ const AssetEditor = () => {
 
   // Render
 
-  const mainComponent = previewVisible ? (
-    <div className="grow row">
-      <Preview assetData={assetData} setAssetData={setAssetData} />
-    </div>
-  ) : (
-    <main className="grow column">
-      <AssetMainProps
-        assetData={assetData}
-        setMeta={setMeta}
-        enabledActions={enabledActions}
-      />
-      <section
-        className={clsx('grow', 'column', {
-          'section-changed': isChanged,
-        })}
-        style={{ minWidth: 500 }}
-      >
-        <div className="contained" style={{ overflowY: 'scroll', padding: 10 }}>
-          {loading && (
-            <div className="contained center">
-              <Loader />
-            </div>
-          )}
-          <EditorForm
-            onSave={onSave}
-            originalData={originalData}
-            assetData={assetData}
-            setAssetData={setAssetData}
-            fields={fields}
-            disabled={!enabledActions.edit}
-          />
-        </div>
-      </section>
-    </main>
-  )
+  const mainComponent = () => {
+    switch (editorMode) {
+      case 'preview':
+        return (
+          <div className="grow row">
+            <Preview assetData={assetData} setAssetData={setAssetData} />
+          </div>
+        )
+
+      default:
+        return (
+          <main className="grow column">
+            <AssetMainProps
+              assetData={assetData}
+              setMeta={setMeta}
+              enabledActions={enabledActions}
+            />
+            <section
+              className={clsx('grow', 'column', {
+                'section-changed': isChanged,
+              })}
+              style={{ minWidth: 500 }}
+            >
+              <div
+                className="contained"
+                style={{ overflowY: 'scroll', padding: 10 }}
+              >
+                {loading && (
+                  <div className="contained center">
+                    <Loader />
+                  </div>
+                )}
+                <EditorForm
+                  onSave={onSave}
+                  originalData={originalData}
+                  assetData={assetData}
+                  setAssetData={setAssetData}
+                  fields={fields}
+                  disabled={!enabledActions.edit}
+                />
+              </div>
+            </section>
+          </main>
+        )
+    }
+  }
 
   return (
     <div className="grow column">
@@ -341,11 +349,11 @@ const AssetEditor = () => {
         onSave={onSave}
         setMeta={setMeta}
         isChanged={isChanged}
-        previewVisible={previewVisible}
-        setPreviewVisible={setPreviewVisible}
+        editorMode={editorMode}
+        setEditorMode={setEditorMode}
         enabledActions={enabledActions}
       />
-      {Object.keys(assetData || {}).length && mainComponent}
+      {Object.keys(assetData || {}).length && mainComponent()}
       <ConfirmDialog />
     </div>
   )

--- a/frontend/src/pages/AssetEditor/AssetEditor.jsx
+++ b/frontend/src/pages/AssetEditor/AssetEditor.jsx
@@ -17,6 +17,7 @@ import {
 import { Loader } from '/src/components'
 
 import AssetEditorNav from './EditorNav'
+import AssetMainProps from './AssetMainProps'
 import EditorForm from './EditorForm'
 import Preview from './Preview'
 
@@ -294,6 +295,42 @@ const AssetEditor = () => {
 
   // Render
 
+  const mainComponent = previewVisible ? (
+    <div className="grow row">
+      <Preview assetData={assetData} setAssetData={setAssetData} />
+    </div>
+  ) : (
+    <main className="grow column">
+      <AssetMainProps
+        assetData={assetData}
+        setMeta={setMeta}
+        enabledActions={enabledActions}
+      />
+      <section
+        className={clsx('grow', 'column', {
+          'section-changed': isChanged,
+        })}
+        style={{ minWidth: 500 }}
+      >
+        <div className="contained" style={{ overflowY: 'scroll', padding: 10 }}>
+          {loading && (
+            <div className="contained center">
+              <Loader />
+            </div>
+          )}
+          <EditorForm
+            onSave={onSave}
+            originalData={originalData}
+            assetData={assetData}
+            setAssetData={setAssetData}
+            fields={fields}
+            disabled={!enabledActions.edit}
+          />
+        </div>
+      </section>
+    </main>
+  )
+
   return (
     <div className="grow column">
       <AssetEditorNav
@@ -308,42 +345,7 @@ const AssetEditor = () => {
         setPreviewVisible={setPreviewVisible}
         enabledActions={enabledActions}
       />
-
-      {Object.keys(assetData || {}).length ? (
-        <div className="grow row">
-          {!previewVisible && (
-            <section
-              className={clsx('grow', 'column', {
-                'section-changed': isChanged,
-              })}
-              style={{ minWidth: 500 }}
-            >
-              <div
-                className="contained"
-                style={{ overflowY: 'scroll', padding: 10 }}
-              >
-                {loading && (
-                  <div className="contained center">
-                    <Loader />
-                  </div>
-                )}
-                <EditorForm
-                  onSave={onSave}
-                  originalData={originalData}
-                  assetData={assetData}
-                  setAssetData={setAssetData}
-                  fields={fields}
-                  disabled={!enabledActions.edit}
-                />
-              </div>
-            </section>
-          )}
-
-          {previewVisible && (
-            <Preview assetData={assetData} setAssetData={setAssetData} />
-          )}
-        </div>
-      ) : null}
+      {Object.keys(assetData || {}).length && mainComponent}
       <ConfirmDialog />
     </div>
   )

--- a/frontend/src/pages/AssetEditor/AssetMainProps.jsx
+++ b/frontend/src/pages/AssetEditor/AssetMainProps.jsx
@@ -26,17 +26,7 @@ import AssigneesButton from './AssigneesButton'
 
 import contentType from 'content-type'
 
-const AssetEditorNav = ({
-  assetData,
-  onNewAsset,
-  onCloneAsset,
-  onRevert,
-  onSave,
-  setMeta,
-  previewVisible,
-  setPreviewVisible,
-  enabledActions,
-}) => {
+const AssetEditorNav = ({ assetData, setMeta, enabledActions }) => {
   const [detailsVisible, setDetailsVisible] = useState(false)
   const [contextActionResult, setContextActionResult] = useState(null)
   const dispatch = useDispatch()
@@ -135,73 +125,54 @@ const AssetEditorNav = ({
         />
       )}
 
-      <Button
-        icon="add"
-        onClick={onNewAsset}
-        label="New asset"
-        disabled={!enabledActions.create}
-      />
-      <Button
-        icon="content_copy"
-        onClick={onCloneAsset}
-        label="Clone asset"
-        disabled={!enabledActions.clone}
+      <Dropdown
+        options={folderOptions}
+        buttonStyle={{
+          borderLeft: ` 4px solid ${currentFolder?.color}`,
+          minWidth: 130,
+          width: 130,
+        }}
+        label={currentFolder?.name || 'no folder'}
+        disabled={!enabledActions.folderChange}
       />
 
-      <Spacer />
+      <InputTimecode
+        value={assetData?.duration}
+        fps={fps}
+        onChange={(val) => setMeta('duration', val)}
+        tooltip="Asset duration"
+        readOnly={assetData.status || !enabledActions.edit}
+      />
 
-      {nebula.settings.system.ui_asset_preview && (
-        <Button
-          icon="visibility"
-          onClick={() => setPreviewVisible(!previewVisible)}
-          active={previewVisible}
-          tooltip="Toggle video preview"
+      <ToolbarSeparator />
+
+      {enabledActions.advanced && (
+        <AssigneesButton
+          assignees={assetData?.assignees || []}
+          setAssignees={(val) => setMeta('assignees', val)}
         />
       )}
 
-      <ToolbarSeparator />
+      <Spacer />
 
-      <Button
-        icon="flag"
-        style={{ color: 'var(--color-text)' }}
-        tooltip="Revert QC state"
-        onClick={() => setMeta('qc/state', 0)}
-        className={!(assetData && assetData['qc/state']) ? 'active' : ''}
-        disabled={!enabledActions.flag}
-      />
-      <Button
-        icon="flag"
-        style={{ color: 'var(--color-red)' }}
-        tooltip="Reject asset"
-        onClick={() => setMeta('qc/state', 3)}
-        className={assetData && assetData['qc/state'] === 3 ? 'active' : ''}
-        active={assetData && assetData['qc/state'] === 3}
-        disabled={!enabledActions.flag}
-      />
-      <Button
-        icon="flag"
-        style={{ color: 'var(--color-green)' }}
-        tooltip="Approve asset"
-        onClick={() => setMeta('qc/state', 4)}
-        className={assetData && assetData['qc/state'] === 4 ? 'active' : ''}
-        active={assetData && assetData['qc/state'] === 4}
-        disabled={!enabledActions.flag}
-      />
+      {enabledActions.advanced && (
+        <>
+          <Dropdown
+            options={assetActions}
+            disabled={!enabledActions.actions}
+            label="Actions"
+          />
+          <Button
+            icon="manage_search"
+            label="Details"
+            onClick={() => setDetailsVisible(true)}
+          />
+        </>
+      )}
 
-      <ToolbarSeparator />
-
-      <Button
-        icon="backspace"
-        label="Discard changes"
-        onClick={onRevert}
-        disabled={!enabledActions.revert}
-      />
-      <Button
-        icon="check"
-        label="Save asset"
-        onClick={() => onSave()}
-        disabled={!enabledActions.save}
-      />
+      {nebula.settings?.system?.ui_asset_upload && (
+        <UploadButton assetData={assetData} disabled={!enabledActions.upload} />
+      )}
     </Navbar>
   )
 }

--- a/frontend/src/pages/AssetEditor/AssigneesButton.jsx
+++ b/frontend/src/pages/AssetEditor/AssigneesButton.jsx
@@ -31,7 +31,7 @@ const AssigneesButton = ({ assignees, setAssignees }) => {
       )}
       <Button
         icon="person"
-        tooltip="Assignees"
+        label="Assignees"
         onClick={() => setDialogVisible(true)}
         active={assignees?.length > 0}
       />

--- a/frontend/src/pages/AssetEditor/EditorNav.jsx
+++ b/frontend/src/pages/AssetEditor/EditorNav.jsx
@@ -1,25 +1,28 @@
 import nebula from '/src/nebula'
 
-import contentType from 'content-type'
-import { useDispatch } from 'react-redux'
-import { useState, useMemo } from 'react'
-import {
-  setCurrentViewId,
-  setSearchQuery,
-  showSendToDialog,
-} from '/src/actions'
-
 import {
   Navbar,
   Button,
   Spacer,
   RadioButton,
   ToolbarSeparator,
-  Dialog,
 } from '/src/components'
 
-import MetadataDetail from './MetadataDetail'
-import ContextActionResult from './ContextAction'
+const QC_STATE_OPTIONS = [
+  { value: 0, icon: 'flag', tooltip: 'Revert QC state' },
+  {
+    value: 3,
+    icon: 'flag',
+    buttonStyle: { color: 'var(--color-red)' },
+    tooltip: 'Reject asset',
+  },
+  {
+    value: 4,
+    icon: 'flag',
+    buttonStyle: { color: 'var(--color-green)' },
+    tooltip: 'Approve asset',
+  },
+]
 
 const AssetEditorNav = ({
   assetData,
@@ -32,16 +35,6 @@ const AssetEditorNav = ({
   setEditorMode,
   enabledActions,
 }) => {
-  const dispatch = useDispatch()
-
-  const currentFolder = useMemo(() => {
-    if (!nebula.settings.folders) return null
-    for (const f of nebula.settings.folders) {
-      if (f.id !== assetData?.id_folder) continue
-      return f
-    }
-  }, [{ ...assetData }])
-
   return (
     <Navbar>
       <Button
@@ -72,21 +65,7 @@ const AssetEditorNav = ({
 
       <RadioButton
         value={assetData['qc/state']}
-        options={[
-          { value: 0, icon: 'flag', tooltip: 'Revert QC state' },
-          {
-            value: 3,
-            icon: 'flag',
-            buttonStyle: { color: 'var(--color-red)' },
-            tooltip: 'Reject asset',
-          },
-          {
-            value: 4,
-            icon: 'flag',
-            buttonStyle: { color: 'var(--color-green)' },
-            tooltip: 'Approve asset',
-          },
-        ]}
+        options={QC_STATE_OPTIONS}
         onChange={(value) => setMeta('qc/state', value)}
         disabled={!enabledActions.flag}
       />


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/74a734b4-d0c2-4945-a402-b7c093472552)

This update enhances the asset editor interface by dividing the toolbar into two distinct sections, resulting in a less cramped and more descriptive layout.

### Main Toolbar

Create or clone assets, save the current asset, set its QC state, and switch between metadata and preview modes.

### Second Toolbar (Metadata Mode)

Change the asset's folder, adjust its duration, and execute asset-related actions.

By providing more space, this redesign allows for larger buttons with labels, reducing confusion and minimizing reliance on tooltips.

