### PR TITLE
Fix toasts being obscured by dialog shade

### DIFF
--- a/frontend/src/components/Dialog.jsx
+++ b/frontend/src/components/Dialog.jsx
@@ -25,6 +25,7 @@ const StyledDialog = styled.dialog`
   &::backdrop {
     background-color: rgba(0, 0, 0, 0);
     backdrop-filter: none;
+    z-index: 999; // P5e04
   }
 
   &[open] {

--- a/frontend/src/containers/Upload.jsx
+++ b/frontend/src/containers/Upload.jsx
@@ -2,7 +2,6 @@ import axios from 'axios'
 import styled from 'styled-components'
 
 import { useState, useRef, useMemo } from 'react'
-import { toast } from 'react-toastify'
 import { Dialog, Button, Progress } from '/src/components'
 
 import nebula from '/src/nebula'
@@ -134,7 +133,7 @@ const UploadDialog = ({ onHide, assetData }) => {
 
   const handleHide = () => {
     if (status === 'uploading') {
-      toast.error('Upload in progress')
+      console.warn('Unable to close dialog: upload in progress')
       return
     }
     onHide()
@@ -159,18 +158,11 @@ const UploadDialog = ({ onHide, assetData }) => {
       })
 
       setStatus('success')
-      toast.success('Upload finished')
     } catch (error) {
       console.error(error)
       if (axios.isCancel(error)) {
         console.error('Request canceled', error.message)
       } else if (error.response) {
-        toast.error(
-          <>
-            <strong>Upload failed</strong>
-            <p>{error.response.data?.detail || 'Unknown error'}</p>
-          </>
-        )
         console.error('Error response', error.response)
       }
       setBytesTransferred(0)


### PR DESCRIPTION
The modal dialog is it the top layer, so it will always cover the toasts. The workaround is: do not use toasts from dialogs and use in-dialog notifications instead. AFAIK it is only the case of "upload successful/failed" notification in the upload dialog - which would make sense to be persistent anyways.