### PR TITLE
Remove granian support

### DIFF
--- a/backend/api/proxy.py
+++ b/backend/api/proxy.py
@@ -1,156 +1,11 @@
 import os
 
-import aiofiles
-from fastapi import HTTPException, Request, Response, status
+from fastapi import Request
+from fastapi.responses import FileResponse
 
 import nebula
 from server.dependencies import CurrentUser
 from server.request import APIRequest
-
-MAX_200_SIZE = 1024 * 1024 * 12
-
-
-class ProxyResponse(Response):
-    content_type = "video/mp4"
-
-
-def get_file_size(file_name: str) -> int:
-    """Get the size of a file"""
-    if not os.path.exists(file_name):
-        raise nebula.NotFoundException("File not found")
-    return os.stat(file_name).st_size
-
-
-async def get_bytes_range2(file_name: str, start: int, end: int) -> bytes:
-    """Get a range of bytes from a file"""
-    async with aiofiles.open(file_name, mode="rb") as f:
-        await f.seek(start)
-        pos = start
-        read_size = end - pos + 1
-        return await f.read(read_size)
-
-
-async def get_bytes_range(
-    file_name: str, start: int, end: int, request: Request
-) -> bytes:
-    """Get a range of bytes from a file"""
-    async with aiofiles.open(file_name, mode="rb") as f:
-        await f.seek(start)
-        pos = start
-        read_size = end - pos + 1
-        chunk_size = 1024 * 64  # Read in chunks of 64KB
-        data = bytearray()
-
-        while read_size > 0:
-            if await request.is_disconnected():
-                raise HTTPException(
-                    status_code=status.HTTP_499_CLIENT_CLOSED_REQUEST,
-                    detail="Client disconnected",
-                )
-
-            chunk = await f.read(min(chunk_size, read_size))
-            if not chunk:
-                break
-            data.extend(chunk)
-            read_size -= len(chunk)
-
-        return bytes(data)
-
-
-def _get_range_header(range_header: str, file_size: int) -> tuple[int, int]:
-    """
-    Parse the Range header to determine the start and end byte positions.
-
-    Args:
-        range_header (str): The value of the Range header from the HTTP request.
-        file_size (int): The total size of the file in bytes.
-
-    Returns:
-        tuple[int, int]: A tuple containing the start and end byte positions.
-
-    Raises:
-        HTTPException: If the range is invalid or cannot be parsed.
-    """
-
-    def _invalid_range() -> HTTPException:
-        return HTTPException(
-            status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE,
-            detail=f"Invalid request range (Range:{range_header!r})",
-        )
-
-    try:
-        h = range_header.replace("bytes=", "").split("-")
-        start = int(h[0]) if h[0] != "" else 0
-        end = int(h[1]) if h[1] != "" else file_size - 1
-    except ValueError as e:
-        raise _invalid_range() from e
-
-    if start > end or start < 0 or end > file_size - 1:
-        raise _invalid_range()
-    return start, end
-
-
-async def range_requests_response(
-    request: Request, file_path: str, content_type: str
-) -> ProxyResponse:
-    """Returns StreamingResponse using Range Requests of a given file"""
-
-    file_size = get_file_size(file_path)
-
-    max_chunk_size = 1024 * 1024 * 4
-    range_header = request.headers.get("range")
-    max_200_size = MAX_200_SIZE
-
-    # screw firefox
-    if ua := request.headers.get("user-agent"):
-        if "firefox" in ua.lower():
-            max_chunk_size = file_size
-        elif "safari" in ua.lower():
-            max_200_size = 0
-
-    headers = {
-        "content-type": content_type,
-        "content-length": str(file_size),
-        "accept-ranges": "bytes",
-        "access-control-expose-headers": (
-            "content-type, accept-ranges, content-length, "
-            "content-range, content-encoding"
-        ),
-    }
-    start = 0
-    end = file_size - 1
-    status_code = status.HTTP_200_OK
-
-    if file_size <= max_200_size:
-        # if the file has a sane size, we return the whole thing
-        # in one go. That allows the browser to cache the video
-        # and prevent unnecessary requests.
-
-        headers["content-range"] = f"bytes 0-{end}/{file_size}"
-
-    elif range_header is not None:
-        start, end = _get_range_header(range_header, file_size)
-        end = min(end, start + max_chunk_size - 1, file_size - 1)
-
-        size = end - start + 1
-        headers["content-length"] = str(size)
-        headers["content-range"] = f"bytes {start}-{end}/{file_size}"
-
-        if size == file_size:
-            status_code = status.HTTP_200_OK
-        else:
-            status_code = status.HTTP_206_PARTIAL_CONTENT
-
-    payload = await get_bytes_range(file_path, start, end, request)
-
-    if status_code == status.HTTP_200_OK:
-        headers["cache-control"] = "private, max-age=600"
-
-    return ProxyResponse(
-        content=payload,
-        headers=headers,
-        status_code=status_code,
-    )
 
 
 class ServeProxy(APIRequest):
@@ -170,7 +25,7 @@ class ServeProxy(APIRequest):
         request: Request,
         id_asset: int,
         user: CurrentUser,
-    ) -> ProxyResponse:
+    ) -> FileResponse:
         sys_settings = nebula.settings.system
         proxy_storage_path = nebula.storages[sys_settings.proxy_storage].local_path
         proxy_path_template = os.path.join(proxy_storage_path, sys_settings.proxy_path)
@@ -186,8 +41,4 @@ class ServeProxy(APIRequest):
             # maybe return content too? with a placeholder image?
             raise nebula.NotFoundException("Proxy not found")
 
-        try:
-            return await range_requests_response(request, video_path, "video/mp4")
-        except Exception as e:
-            nebula.log.traceback("Error serving proxy")
-            raise nebula.NebulaException("Error serving proxy") from e
+        return FileResponse(video_path, media_type="video/mp4")

--- a/backend/manage
+++ b/backend/manage
@@ -1,67 +1,75 @@
 #!/bin/bash
 
-SERVER_TYPE=${NEBULA_SERVER_TYPE:-gunicorn}
+SERVER_PORT=${NEBULA_SERVER_PORT:-80}
+SERVER_WORKERS=${NEBULA_SERVER_WORKERS:-1}
 
-if [ $# -ne 1 ]; then
-  echo "Error: a single argument is required"
-  exit 1
+# Maximum number of requests a worker will process before restarting
+# If we have only one worker, we keep it running indefinitely
+
+if [ $SERVER_WORKERS -eq 1 ]; then
+    MAX_REQUESTS=0
+else
+    MAX_REQUESTS=${NEBULA_SERVER_MAX_REQUESTS:-1000}
 fi
 
-function start_server () {
-  echo ""
-  echo "Starting the server..."
-  echo ""
 
-  # Run setup to make sure database is up to date
-  python -m setup
-
-  
-  if [ $SERVER_TYPE = "gunicorn" ]; then
-    exec gunicorn \
-      -k uvicorn.workers.UvicornWorker \
-      --log-level warning \
-      -b :80 \
-      server.server:app
-  elif [ $SERVER_TYPE = "granian" ]; then
-    exec granian \
-      --interface asgi \
-      --log-level warning \
-      --host 0.0.0.0 \
-      --port 80 \
-      server.server:app
-  else
-    echo ""
-    echo "Error: invalid server type '$SERVER_TYPE'. Expected 'gunicorn' or 'granian'"
-    echo ""
+if [ $# -ne 1 ]; then
+    echo "Error: a single argument is required"
     exit 1
-  fi
+fi
+
+function setup () {
+    echo ""
+    echo "Running setup..."
+    echo ""
+    python -m setup
+}
+
+function serve () {
+    echo ""
+    echo "Starting the server..."
+    echo ""
+    # Run setup to make sure database is up to date
+    exec gunicorn \
+        --name nebula-gunicorn \
+        --bind :${SERVER_PORT} \
+        --workers ${SERVER_WORKERS} \
+        --worker-class uvicorn_worker.UvicornWorker \
+        --max-requests ${MAX_REQUESTS} \
+        --log-level warning \
+        --pid /tmp/nebula-gunicorn.pid \
+        server.server:app
+}
+
+function start_server () {
+    # This is the entry point for the Docker container
+    # It starts the setup and then the server
+    # In production, both tasks could be run individually
+    # (setup in a init container, server in the main
+    # container with multiple replicas)
+    setup || exit 1
+    serve || exit 1
 }
 
 
 function get_server_pid () {
-  if [ $SERVER_TYPE = "gunicorn" ]; then
-    pid=$(ps aux | grep 'gunicorn' | awk '{print $2}')
-  elif [ $SERVER_TYPE = "granian" ]; then
-    pid=$(ps aux | grep 'granian' | awk '{print $2}')
-  fi
-  echo $pid
+    cat /tmp/nebula-gunicorn.pid 2> /dev/null
 }
 
-
 function stop_server () {
-  echo ""
-  echo "SIGTERM signal received. Shutting down..."
-  echo ""
-  kill -TERM $(get_server_pid) 2> /dev/null
-  exit 0
+    echo ""
+    echo "SIGTERM signal received. Shutting down..."
+    echo ""
+    kill -TERM $(get_server_pid) 2> /dev/null
+    exit 0
 }
 
 function reload_server () {
-  echo ""
-  echo "Reloading the server..."
-  echo ""
-  kill -HUP $(get_server_pid) 2> /dev/null
-  exit 0
+    echo ""
+    echo "Reloading the server..."
+    echo ""
+    kill -HUP $(get_server_pid) 2> /dev/null
+    exit 0
 }
 
 trap stop_server SIGTERM SIGINT
@@ -69,14 +77,18 @@ trap reload_server SIGHUP
 
 
 if [ $1 = "start" ]; then
-  start_server
+    start_server
 elif [ $1 = "stop" ]; then
-  stop_server
+    stop_server
 elif [ $1 = "reload" ]; then
-  reload_server
+    reload_server
+elif [ $1 = "setup" ]; then
+    setup
+elif [ $1 = "serve" ]; then
+    serve
 else
-  echo ""
-  echo "Error: invalid argument '$1'. Expected 'start' or 'reload'"
-  echo ""
-  exit 1
+    echo ""
+    echo "Error: invalid argument '$1'"
+    echo ""
+    exit 1
 fi

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "email-validator >=2.1.1",
     "fastapi >=0.115.0",
     "geoip2 >=4.8.0",
-    "granian >=1.6.0",
     "gunicorn >=22.0.0",
     "httpx >=0.27.2",
     "mistune >=3.0.1",
@@ -22,6 +21,7 @@ dependencies = [
     "rich >=13.8.0",
     "shortuuid >=1.0.12",
     "user-agents >=2.2.0",
+    "uvicorn-worker>=0.3.0",
     "uvicorn[standard] >=0.31.0",
 ]
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -313,32 +313,6 @@ wheels = [
 ]
 
 [[package]]
-name = "granian"
-version = "1.7.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "uvloop", marker = "platform_python_implementation == 'CPython' and sys_platform != 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/ce/165a84b8b950bbce3b2b8d2d2a6ab4309476c13df0ecd1cf4dc29d8c1cd3/granian-1.7.6.tar.gz", hash = "sha256:5e36d28b947b2c18bc7dc61072b3aa67c28b28d871f55a4daabea8eb6300e50e", size = 82592 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/5d/96c291d8308b30f4c78cafe664267876a0251acc462d0359c80547fcecc2/granian-1.7.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b09bc979299e5b3c77fcc55ac3f430125e5f4739e139321851f61f4f49aaf490", size = 2484970 },
-    { url = "https://files.pythonhosted.org/packages/f6/d9/e3a19940ca8038f1dbe6a96b3248e4684a693cdd9211a7408692050a6dfd/granian-1.7.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c1fa2660923d4c27f5a827ad0fcb8156f9213fdcac94fe75f68d502e9c432a92", size = 2235264 },
-    { url = "https://files.pythonhosted.org/packages/76/62/8fa26963d85371a945e396d2a575e6fe40bfe3cc1f490f80f6e87f36a744/granian-1.7.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd3aa566a958194b9e727829e2efc8d4451b415e9df0b9abdf879a79c737c5f1", size = 2216089 },
-    { url = "https://files.pythonhosted.org/packages/99/f9/b1cd3612059f710b8f093780f90a9f3ff111f61cded3928f7f032ad69a2a/granian-1.7.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0f778d28e73a4fadc6dd9d559d32e30700739cb53f71e0f3aa282fee1ec2bdd", size = 2343751 },
-    { url = "https://files.pythonhosted.org/packages/e2/b1/632278eaf3abd05a7bc4f294149cc7592ee06464031700b33ce9e74f614d/granian-1.7.6-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:2acd12b1ebdab7995fd39ec796b0ccae6a1650a0cae4aec29746e3c707ccfa33", size = 2415360 },
-    { url = "https://files.pythonhosted.org/packages/66/7e/e89ad3c0ef0f4e36a24aa4a22fd27e06da437291755081c9bcc5d301bb96/granian-1.7.6-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:38facbb095c2e4e7c41c3070101fa8ccc1782b26dd6c4f504fca6419cb48b5ae", size = 2536488 },
-    { url = "https://files.pythonhosted.org/packages/80/3b/1506faa510e1dd2de3dc1ec7c739c8dd259186fe0760694191347509fc4b/granian-1.7.6-cp311-cp311-win_amd64.whl", hash = "sha256:00a1bdd070bd38547b84e70523636a1fca346b721b8ba160feb7e747639976b8", size = 2477212 },
-    { url = "https://files.pythonhosted.org/packages/d5/af/8a5d77ef2d80be4ddb7b117d4dfffa29fc17deea46b2ae8285581a210619/granian-1.7.6-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8ac0c2f6c276aefee71f4b5cb52aca01fa2904eb80f93aaa89972ef2f7e61512", size = 2485011 },
-    { url = "https://files.pythonhosted.org/packages/b8/66/a012d28413145ce257ec01b79af30823af6264c016511315abd447613167/granian-1.7.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5fc920bef1704b41da9db12f59818c876916bbeab35a77da9d38a6d0b685d05a", size = 2234710 },
-    { url = "https://files.pythonhosted.org/packages/28/57/98ec5c558c9759a7c5ccd1720527fa7842c167422637bab53943ecf9692c/granian-1.7.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97b77d4827971e35245db52e22df22fc570524c0a47434a2e80b80a7c6930d59", size = 2209665 },
-    { url = "https://files.pythonhosted.org/packages/9e/03/eb9071203aec1267547ca1e674a18f6610d5f78ed7ccd7787b3e244abbe5/granian-1.7.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3375f1a1d6d9d514dc6cd614262c508b4d232615a98f0d0cddaf092d9bb32661", size = 2342459 },
-    { url = "https://files.pythonhosted.org/packages/5a/e2/68524eddfd81b506acda8d6dd6e3bb7161f62cc70bc05435a416de9e6fdd/granian-1.7.6-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c3c60f8ed1e8c00c63640ff0b52a2c7f9afd0cbbaf873e5ee1e989bbff6829a6", size = 2413100 },
-    { url = "https://files.pythonhosted.org/packages/43/f7/f4f4f386d1775dff7b7fe327c9c999aa766cdb882f3f82634b048ace561f/granian-1.7.6-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ac123facbde9cea601f633a76767a6e91ce009d7b0837f54cc472881730986b3", size = 2536006 },
-    { url = "https://files.pythonhosted.org/packages/f7/7a/7a0827be2a7b62ee27df9d2225a03adde7020c1e78b43abb340992b3875a/granian-1.7.6-cp312-cp312-win_amd64.whl", hash = "sha256:0fc6b439cf6581d5dfc27e0f4fdbda475e2dc096d4e5325a8d1778e990dbf1e7", size = 2473999 },
-]
-
-[[package]]
 name = "gunicorn"
 version = "23.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -568,7 +542,6 @@ dependencies = [
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "geoip2" },
-    { name = "granian" },
     { name = "gunicorn" },
     { name = "httpx" },
     { name = "mistune" },
@@ -581,6 +554,7 @@ dependencies = [
     { name = "shortuuid" },
     { name = "user-agents" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn-worker" },
 ]
 
 [package.dev-dependencies]
@@ -601,7 +575,6 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.1.1" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "geoip2", specifier = ">=4.8.0" },
-    { name = "granian", specifier = ">=1.6.0" },
     { name = "gunicorn", specifier = ">=22.0.0" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "mistune", specifier = ">=3.0.1" },
@@ -614,6 +587,7 @@ requires-dist = [
     { name = "shortuuid", specifier = ">=1.0.12" },
     { name = "user-agents", specifier = ">=2.2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.31.0" },
+    { name = "uvicorn-worker", specifier = ">=0.3.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1020,6 +994,19 @@ standard = [
     { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
     { name = "watchfiles" },
     { name = "websockets" },
+]
+
+[[package]]
+name = "uvicorn-worker"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gunicorn" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/c0/b5df8c9a31b0516a47703a669902b362ca1e569fed4f3daa1d4299b28be0/uvicorn_worker-0.3.0.tar.gz", hash = "sha256:6baeab7b2162ea6b9612cbe149aa670a76090ad65a267ce8e27316ed13c7de7b", size = 9181 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/1f/4e5f8770c2cf4faa2c3ed3c19f9d4485ac9db0a6b029a7866921709bdc6c/uvicorn_worker-0.3.0-py3-none-any.whl", hash = "sha256:ef0fe8aad27b0290a9e602a256b03f5a5da3a9e5f942414ca587b645ec77dd52", size = 5346 },
 ]
 
 [[package]]


### PR DESCRIPTION
* Removed custom range request handling and related utility functions, simplifying the file response logic by using `FileResponse` from FastAPI.
* Introduced new environment variables and logic to control server port, worker count, and maximum requests per worker.
* Added `setup` and `serve` functions to separate setup and server start logic, and updated the script to handle new commands 
* Removed `granian` dependency and added `uvicorn-worker` to align with the updated server management script.