### PR TITLE
Allow setting preview and marks position using timecode inputs

### DIFF
--- a/frontend/src/containers/VideoPlayer/VideoPlayerBody.jsx
+++ b/frontend/src/containers/VideoPlayer/VideoPlayerBody.jsx
@@ -239,6 +239,7 @@ const VideoPlayerBody = ({ ...props }) => {
           mode="frames"
           tooltip="Current position"
           fps={props.frameRate}
+          onChange={(v) => seekToFrame(v)}
         />
         <ChannelSelect gainNodes={gainNodes} />
         <div style={{ flex: 1 }} />

--- a/frontend/src/containers/VideoPlayer/VideoPlayerControls.jsx
+++ b/frontend/src/containers/VideoPlayer/VideoPlayerControls.jsx
@@ -213,6 +213,7 @@ const VideoPlayerControls = ({
         mode="frames"
         tooltip="Selection start"
         fps={frameRate}
+        onChange={setMarkIn}
       />
 
       <Button
@@ -290,6 +291,7 @@ const VideoPlayerControls = ({
         mode="frames"
         tooltip="Selection end"
         fps={frameRate}
+        onChange={setMarkOut}
       />
     </Navbar>
   );


### PR DESCRIPTION
This pull request enhances the interactivity of the video player controls by adding `onChange` event handlers to the timecode inputs in both `VideoPlayerBody` and `VideoPlayerControls`. These handlers allow users to seek to specific frames and set selection markers directly from the UI.