### PR TITLE
Fix: increasing storage usage bar

### DIFF
--- a/backend/api/stats/storages.py
+++ b/backend/api/stats/storages.py
@@ -185,7 +185,7 @@ class NebulaStoragesRequest(APIRequest):
                 )
                 continue
 
-            usage = await get_nebula_folders_usage(storage_id)
+            usage = list(await get_nebula_folders_usage(storage_id))
             playout_usage = await get_nebula_playout_usage(storage_id)
             if playout_usage.usage > 0:
                 usage.append(playout_usage)


### PR DESCRIPTION
This pull request makes a small adjustment to the way folder usage data is handled in the `handle` function of `backend/api/stats/storages.py`. The main change is converting the result of `get_nebula_folders_usage` into a list to ensure that the subsequent `append` operation does not mutate the cached list.